### PR TITLE
When token is specified in the kwargs, use it regardless of the value

### DIFF
--- a/ebaysuds/client.py
+++ b/ebaysuds/client.py
@@ -45,16 +45,19 @@ class EbaySuds(object):
 
         # do the authentication ritual
         credentials = self.sudsclient.factory.create('RequesterCredentials')
-        credentials.eBayAuthToken = kwargs.get('token') or ebaysuds_config.get('auth', 'token')
+        try:
+            credentials.eBayAuthToken = kwargs['token']
+        except KeyError:
+            credentials.eBayAuthToken = ebaysuds_config.get('auth', 'token')
         credentials.Credentials.AppId = self.app_id
         credentials.Credentials.DevId = kwargs.get('dev_id') or ebaysuds_config.get('keys', 'dev_id')
         credentials.Credentials.AuthCert = kwargs.get('cert_id') or ebaysuds_config.get(key_section, 'cert_id')
         self.sudsclient.set_options(soapheaders=credentials)
-        
+
         # find current API version from the WSDL
         service = self.sudsclient.sd[0].service
         self.version = service.root.getChild('documentation').getChild('Version').text
-        
+
         # add querystring to the service URI specified in WSDL
         # (the service URI can be found in service.ports[0].location but there's no sandbox endpoint in the wsdl)
         self.uri_template = endpoint + GATEWAY_URI_QUERYSTRING
@@ -74,6 +77,6 @@ class EbaySuds(object):
             'app_id': self.app_id,
             'version': self.version,
         }
-        
+
         # ...and the method call itself always has to specify an API version (again)
         return partial(method, Version=self.version)

--- a/ebaysuds/client.py
+++ b/ebaysuds/client.py
@@ -45,9 +45,9 @@ class EbaySuds(object):
 
         # do the authentication ritual
         credentials = self.sudsclient.factory.create('RequesterCredentials')
-        try:
+        if 'token' in kwargs:
             credentials.eBayAuthToken = kwargs['token']
-        except KeyError:
+        else:
             credentials.eBayAuthToken = ebaysuds_config.get('auth', 'token')
         credentials.Credentials.AppId = self.app_id
         credentials.Credentials.DevId = kwargs.get('dev_id') or ebaysuds_config.get('keys', 'dev_id')


### PR DESCRIPTION
## Issue

Not all eBay api calls require an auth token (GetSessionID). With the current code base when a token is specified as null in the kwargs the token is retrieved from the config. This means that you are not able to make calls to the ebay api with a token in the current implementation
## Solution

Use a try/except to try to get the value of the token. If the token is in the kwargs, and it is None it will still be used. When the token is not in the kwargs the one from the config will be used.
